### PR TITLE
[PIDM-1117] - status recovery

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-tech-support-api
 description: Technical support api
 type: application
-version: "0.75.0"
-appVersion: "1.2.22-1-PIDM-1117-status-recovery"
+version: "0.76.0"
+appVersion: "1.2.22-2-PIDM-1117-status-recovery"
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-tech-support-api
 description: Technical support api
 type: application
-version: "0.73.0"
-appVersion: "1.2.21"
+version: "0.74.0"
+appVersion: "1.2.22"
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-tech-support-api
 description: Technical support api
 type: application
-version: "0.74.0"
-appVersion: "1.2.22"
+version: "0.75.0"
+appVersion: "1.2.22-1-PIDM-1117-status-recovery"
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.22'
+    tag: '1.2.22-1-PIDM-1117-status-recovery'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.22-1-PIDM-1117-status-recovery'
+    tag: '1.2.22-2-PIDM-1117-status-recovery'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.21'
+    tag: '1.2.22'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -76,6 +76,7 @@ microservice-chart:
     COSMOS_BIZ_ENDPOINT: "https://pagopa-d-weu-bizevents-ds-cosmos-account.documents.azure.com:443/"
     COSMOS_NEG_BIZ_ENDPOINT: "https://pagopa-d-weu-bizevents-neg-ds-cosmos-account.documents.azure.com:443/"
     COSMOS_VERIFYKO_ENDPOINT: "https://pagopa-d-weu-nodo-verifyko-cosmos-account.documents.azure.com:443/"
+    COSMOS_PREFERRED_REGION: "West Europe"
     DATASOURCE_USERNAME: "offline"
     DATASOURCE_URL: "jdbc:postgresql://nodo-db.d.internal.postgresql.pagopa.it:5432/nodo" # PAGOPA (Nexi not available)
     DATASOURCE_SCHEMA: "offline"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.22'
+    tag: '1.2.22-1-PIDM-1117-status-recovery'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.22-1-PIDM-1117-status-recovery'
+    tag: '1.2.22-2-PIDM-1117-status-recovery'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -76,6 +76,7 @@ microservice-chart:
     COSMOS_BIZ_ENDPOINT: "https://pagopa-p-weu-bizevents-ds-cosmos-account.documents.azure.com:443/"
     COSMOS_NEG_BIZ_ENDPOINT: "https://pagopa-p-weu-bizevents-neg-ds-cosmos-account.documents.azure.com:443/"
     COSMOS_VERIFYKO_ENDPOINT: "https://pagopa-p-weu-nodo-verifyko-cosmos-account.documents.azure.com:443/"
+    COSMOS_PREFERRED_REGION: "North Europe"
     DATASOURCE_URL: "jdbc:postgresql://db-postgres-ndp.p.db-nodo-pagamenti.com:6432/ndpspcp_ro"
     DATASOURCE_USERNAME: "biz_pagopa_sv"
     DB_SERVICE_IDENTIFIER: "NDP004PROD"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.21'
+    tag: '1.2.22'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.22'
+    tag: '1.2.22-1-PIDM-1117-status-recovery'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -76,6 +76,7 @@ microservice-chart:
     COSMOS_BIZ_ENDPOINT: "https://pagopa-u-weu-bizevents-ds-cosmos-account.documents.azure.com:443/"
     COSMOS_NEG_BIZ_ENDPOINT: "https://pagopa-u-weu-bizevents-neg-ds-cosmos-account.documents.azure.com:443/"
     COSMOS_VERIFYKO_ENDPOINT: "https://pagopa-u-weu-nodo-verifyko-cosmos-account.documents.azure.com:443/"
+    COSMOS_PREFERRED_REGION: "West Europe"
     DATASOURCE_USERNAME: "biz_pagopa_sv"
     #    DATASOURCE_URL: "jdbc:postgresql://db-postgres-ndp-prf.u.db-nodo-pagamenti.com:6432/ndpspcq_ro?prepareThreshold=0&currentSchema=NODO_OFFLINE"
     DATASOURCE_URL: "jdbc:postgresql://10.6.52.94:6432/ndpspca_ro"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.22-1-PIDM-1117-status-recovery'
+    tag: '1.2.22-2-PIDM-1117-status-recovery'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-node-technical-support-worker
-    tag: '1.2.21'
+    tag: '1.2.22'
   readinessProbe:
     httpGet:
       path: /q/health/ready

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Node technical support - API (local) ${service}",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.22"
+    "version": "1.2.22-1-PIDM-1117-status-recovery"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,64 +1,56 @@
 {
-  "openapi": "3.0.3",
-  "info": {
-    "title": "Node technical support - API (local) ${service}",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.22-1-PIDM-1117-status-recovery"
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Node technical support - API (local) ${service}",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "1.2.22-1-PIDM-1117-status-recovery"
   },
-  "servers": [
-    {
-      "url": "${host}/technical-support/nodo/api/v1"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Info",
-      "description": "Info operations"
-    }
-  ],
-  "paths": {
-    "/events/negative/{bizEventId}": {
-      "get": {
-        "tags": [
-          "Events Resource"
-        ],
-        "parameters": [
-          {
-            "name": "bizEventId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+  "servers" : [ {
+    "url" : "${host}/technical-support/nodo/api/v1"
+  } ],
+  "tags" : [ {
+    "name" : "Info",
+    "description" : "Info operations"
+  } ],
+  "paths" : {
+    "/events/negative/{bizEventId}" : {
+      "get" : {
+        "tags" : [ "Events Resource" ],
+        "parameters" : [ {
+          "name" : "bizEventId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsFullResponse"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsFullResponse"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -66,19 +58,17 @@
         }
       }
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Info"
-        ],
-        "summary": "Get info of Node tech support API",
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InfoResponse"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Info" ],
+        "summary" : "Get info of Node tech support API",
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InfoResponse"
                 }
               }
             }
@@ -86,70 +76,63 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/iuv/{iuv}": {
-      "get": {
-        "tags": [
-          "Worker Resource"
-        ],
-        "parameters": [
-          {
-            "name": "iuv",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "organizationFiscalCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "dateFrom",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
-          },
-          {
-            "name": "dateTo",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
+    "/organizations/{organizationFiscalCode}/iuv/{iuv}" : {
+      "get" : {
+        "tags" : [ "Worker Resource" ],
+        "parameters" : [ {
+          "name" : "iuv",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsResponse"
+        }, {
+          "name" : "organizationFiscalCode",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "dateFrom",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        }, {
+          "name" : "dateTo",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -157,78 +140,70 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/iuv/{iuv}/ccp/{ccp}": {
-      "get": {
-        "tags": [
-          "Worker Resource"
-        ],
-        "parameters": [
-          {
-            "name": "ccp",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "organizationFiscalCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "dateFrom",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
-          },
-          {
-            "name": "dateTo",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
+    "/organizations/{organizationFiscalCode}/iuv/{iuv}/ccp/{ccp}" : {
+      "get" : {
+        "tags" : [ "Worker Resource" ],
+        "parameters" : [ {
+          "name" : "ccp",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsFullResponse"
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "organizationFiscalCode",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "dateFrom",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        }, {
+          "name" : "dateTo",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsFullResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -236,70 +211,63 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}": {
-      "get": {
-        "tags": [
-          "Worker Resource"
-        ],
-        "parameters": [
-          {
-            "name": "noticeNumber",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "organizationFiscalCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "dateFrom",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
-          },
-          {
-            "name": "dateTo",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
+    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}" : {
+      "get" : {
+        "tags" : [ "Worker Resource" ],
+        "parameters" : [ {
+          "name" : "noticeNumber",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsResponse"
+        }, {
+          "name" : "organizationFiscalCode",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "dateFrom",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        }, {
+          "name" : "dateTo",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -307,78 +275,70 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}/paymentToken/{paymentToken}": {
-      "get": {
-        "tags": [
-          "Worker Resource"
-        ],
-        "parameters": [
-          {
-            "name": "noticeNumber",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "organizationFiscalCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "paymentToken",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "dateFrom",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
-          },
-          {
-            "name": "dateTo",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
+    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}/paymentToken/{paymentToken}" : {
+      "get" : {
+        "tags" : [ "Worker Resource" ],
+        "parameters" : [ {
+          "name" : "noticeNumber",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsFullResponse"
+        }, {
+          "name" : "organizationFiscalCode",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "paymentToken",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "dateFrom",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        }, {
+          "name" : "dateTo",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsFullResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -386,96 +346,117 @@
         }
       }
     },
-    "/snapshot/organizations/{organizationFiscalCode}": {
-      "get": {
-        "tags": [
-          "Snapshot Resource"
-        ],
-        "parameters": [
-          {
-            "name": "organizationFiscalCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "dateFrom",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
-          },
-          {
-            "name": "dateTo",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/LocalDate"
-            }
-          },
-          {
-            "name": "noticeNumber",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "format": "int64",
-              "default": 1,
-              "minimum": 1,
-              "type": "integer"
-            }
-          },
-          {
-            "name": "paymentToken",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "size",
-            "in": "query",
-            "schema": {
-              "format": "int64",
-              "default": 1000,
-              "minimum": 1,
-              "type": "integer"
+    "/paymentToken/{paymentToken}" : {
+      "get" : {
+        "tags" : [ "Position Payment Snapshot Resource" ],
+        "parameters" : [ {
+          "name" : "paymentToken",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "serviceIdentifier",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PositionPaymentSnapshotDto"
+                }
+              }
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentResponse"
+        }
+      }
+    },
+    "/snapshot/organizations/{organizationFiscalCode}" : {
+      "get" : {
+        "tags" : [ "Snapshot Resource" ],
+        "parameters" : [ {
+          "name" : "organizationFiscalCode",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "dateFrom",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        }, {
+          "name" : "dateTo",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/LocalDate"
+          }
+        }, {
+          "name" : "noticeNumber",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "schema" : {
+            "format" : "int64",
+            "default" : 1,
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        }, {
+          "name" : "paymentToken",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "schema" : {
+            "format" : "int64",
+            "default" : 1000,
+            "minimum" : 1,
+            "type" : "integer"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -484,363 +465,407 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "ErrorCode": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "example": "0500"
+  "components" : {
+    "schemas" : {
+      "ErrorCode" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "string",
+            "example" : "0500"
           },
-          "description": {
-            "type": "string",
-            "example": "An unexpected error has occurred. Please contact support."
+          "description" : {
+            "type" : "string",
+            "example" : "An unexpected error has occurred. Please contact support."
           },
-          "statusCode": {
-            "format": "int32",
-            "type": "integer",
-            "example": 500
+          "statusCode" : {
+            "format" : "int32",
+            "type" : "integer",
+            "example" : 500
           }
         }
       },
-      "FaultBean": {
-        "type": "object",
-        "properties": {
-          "faultCode": {
-            "type": "string"
+      "FaultBean" : {
+        "type" : "object",
+        "properties" : {
+          "faultCode" : {
+            "type" : "string"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "timestamp": {
-            "type": "string"
+          "timestamp" : {
+            "type" : "string"
           }
         }
       },
-      "InfoResponse": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "example": "pagopa-node-tech-support"
+      "InfoResponse" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "example" : "pagopa-node-tech-support"
           },
-          "version": {
-            "type": "string",
-            "example": "1.2.3"
+          "version" : {
+            "type" : "string",
+            "example" : "1.2.3"
           },
-          "environment": {
-            "type": "string",
-            "example": "dev"
+          "environment" : {
+            "type" : "string",
+            "example" : "dev"
           },
-          "description": {
-            "type": "string",
-            "example": "Node tech support API"
+          "description" : {
+            "type" : "string",
+            "example" : "Node tech support API"
           },
-          "errorCodes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ErrorCode"
+          "errorCodes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorCode"
             }
           }
         }
       },
-      "Instant": {
-        "format": "date-time",
-        "type": "string",
-        "example": "2022-03-10T16:15:50Z"
+      "Instant" : {
+        "format" : "date-time",
+        "type" : "string",
+        "example" : "2022-03-10T16:15:50Z"
       },
-      "LocalDate": {
-        "format": "date",
-        "type": "string",
-        "example": "2022-03-10"
+      "LocalDate" : {
+        "format" : "date",
+        "type" : "string",
+        "example" : "2022-03-10"
       },
-      "Metadata": {
-        "type": "object",
-        "properties": {
-          "pageSize": {
-            "format": "int32",
-            "type": "integer",
-            "example": 25
+      "Metadata" : {
+        "type" : "object",
+        "properties" : {
+          "pageSize" : {
+            "format" : "int32",
+            "type" : "integer",
+            "example" : 25
           },
-          "pageNumber": {
-            "format": "int32",
-            "type": "integer",
-            "example": 1
+          "pageNumber" : {
+            "format" : "int32",
+            "type" : "integer",
+            "example" : 1
           },
-          "totPage": {
-            "format": "int32",
-            "type": "integer",
-            "example": 3
+          "totPage" : {
+            "format" : "int32",
+            "type" : "integer",
+            "example" : 3
           }
         }
       },
-      "PaymentFullInfo": {
-        "type": "object",
-        "properties": {
-          "businessProcess": {
-            "type": "string"
+      "PaymentFullInfo" : {
+        "type" : "object",
+        "properties" : {
+          "businessProcess" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "noticeNumber": {
-            "type": "string"
+          "noticeNumber" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "pspId": {
-            "type": "string"
+          "pspId" : {
+            "type" : "string"
           },
-          "brokerPspId": {
-            "type": "string"
+          "brokerPspId" : {
+            "type" : "string"
           },
-          "channelId": {
-            "type": "string"
+          "channelId" : {
+            "type" : "string"
           },
-          "outcome": {
-            "type": "string"
+          "outcome" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string"
+          "status" : {
+            "$ref" : "#/components/schemas/PaymentStatus"
           },
-          "insertedTimestamp": {
-            "type": "string"
+          "insertedTimestamp" : {
+            "type" : "string"
           },
-          "serviceIdentifier": {
-            "type": "string"
+          "serviceIdentifier" : {
+            "type" : "string"
           },
-          "paymentToken": {
-            "type": "string"
+          "paymentToken" : {
+            "type" : "string"
           },
-          "ccp": {
-            "type": "string"
+          "ccp" : {
+            "type" : "string"
           },
-          "positiveBizEvtId": {
-            "type": "string"
+          "positiveBizEvtId" : {
+            "type" : "string"
           },
-          "verifyKoEvtId": {
-            "type": "string"
+          "verifyKoEvtId" : {
+            "type" : "string"
           },
-          "negativeBizEvtId": {
-            "type": "string"
+          "negativeBizEvtId" : {
+            "type" : "string"
           },
-          "faultBean": {
-            "$ref": "#/components/schemas/FaultBean"
+          "faultBean" : {
+            "$ref" : "#/components/schemas/FaultBean"
           },
-          "brokerOrganizationId": {
-            "type": "string"
+          "brokerOrganizationId" : {
+            "type" : "string"
           },
-          "stationId": {
-            "type": "string"
+          "stationId" : {
+            "type" : "string"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "number"
+          "amount" : {
+            "type" : "number"
           },
-          "pmReceipt": {
-            "type": "string"
+          "pmReceipt" : {
+            "type" : "string"
           },
-          "touchPoint": {
-            "type": "string"
+          "touchPoint" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "number"
+          "fee" : {
+            "type" : "number"
           },
-          "feeOrganization": {
-            "type": "number"
+          "feeOrganization" : {
+            "type" : "number"
           }
         }
       },
-      "PaymentInfo": {
-        "type": "object",
-        "properties": {
-          "businessProcess": {
-            "type": "string"
+      "PaymentInfo" : {
+        "type" : "object",
+        "properties" : {
+          "businessProcess" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "noticeNumber": {
-            "type": "string"
+          "noticeNumber" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "pspId": {
-            "type": "string"
+          "pspId" : {
+            "type" : "string"
           },
-          "brokerPspId": {
-            "type": "string"
+          "brokerPspId" : {
+            "type" : "string"
           },
-          "channelId": {
-            "type": "string"
+          "channelId" : {
+            "type" : "string"
           },
-          "outcome": {
-            "type": "string"
+          "outcome" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string"
+          "status" : {
+            "$ref" : "#/components/schemas/PaymentStatus"
           },
-          "insertedTimestamp": {
-            "type": "string"
+          "insertedTimestamp" : {
+            "type" : "string"
           },
-          "serviceIdentifier": {
-            "type": "string"
+          "serviceIdentifier" : {
+            "type" : "string"
           },
-          "paymentToken": {
-            "type": "string"
+          "paymentToken" : {
+            "type" : "string"
           },
-          "ccp": {
-            "type": "string"
+          "ccp" : {
+            "type" : "string"
           },
-          "positiveBizEvtId": {
-            "type": "string"
+          "positiveBizEvtId" : {
+            "type" : "string"
           },
-          "verifyKoEvtId": {
-            "type": "string"
+          "verifyKoEvtId" : {
+            "type" : "string"
           },
-          "negativeBizEvtId": {
-            "type": "string"
+          "negativeBizEvtId" : {
+            "type" : "string"
           },
-          "faultBean": {
-            "$ref": "#/components/schemas/FaultBean"
+          "faultBean" : {
+            "$ref" : "#/components/schemas/FaultBean"
           }
         }
       },
-      "PaymentResponse": {
-        "type": "object",
-        "properties": {
-          "metadata": {
-            "$ref": "#/components/schemas/Metadata"
+      "PaymentResponse" : {
+        "type" : "object",
+        "properties" : {
+          "metadata" : {
+            "$ref" : "#/components/schemas/Metadata"
           },
-          "count": {
-            "format": "int64",
-            "type": "integer",
-            "example": 100
+          "count" : {
+            "format" : "int64",
+            "type" : "integer",
+            "example" : 100
           },
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PositionPaymentSSInfo"
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PositionPaymentSSInfo"
             }
           },
-          "dateFrom": {
-            "$ref": "#/components/schemas/LocalDate"
+          "dateFrom" : {
+            "$ref" : "#/components/schemas/LocalDate"
           },
-          "dateTo": {
-            "$ref": "#/components/schemas/LocalDate"
+          "dateTo" : {
+            "$ref" : "#/components/schemas/LocalDate"
           }
         }
       },
-      "PaymentsFullResponse": {
-        "type": "object",
-        "properties": {
-          "dateFrom": {
-            "$ref": "#/components/schemas/LocalDate"
-          },
-          "dateTo": {
-            "$ref": "#/components/schemas/LocalDate"
-          },
-          "count": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentFullInfo"
-            }
-          }
-        }
+      "PaymentStatus" : {
+        "enum" : [ "completed", "failed", "cancelled", "unknown" ],
+        "type" : "string"
       },
-      "PaymentsResponse": {
-        "type": "object",
-        "properties": {
-          "dateFrom": {
-            "$ref": "#/components/schemas/LocalDate"
+      "PaymentsFullResponse" : {
+        "type" : "object",
+        "properties" : {
+          "dateFrom" : {
+            "$ref" : "#/components/schemas/LocalDate"
           },
-          "dateTo": {
-            "$ref": "#/components/schemas/LocalDate"
+          "dateTo" : {
+            "$ref" : "#/components/schemas/LocalDate"
           },
-          "count": {
-            "format": "int32",
-            "type": "integer"
+          "count" : {
+            "format" : "int32",
+            "type" : "integer"
           },
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentInfo"
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentFullInfo"
             }
           }
         }
       },
-      "PositionPaymentSSInfo": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "PaymentsResponse" : {
+        "type" : "object",
+        "properties" : {
+          "dateFrom" : {
+            "$ref" : "#/components/schemas/LocalDate"
           },
-          "noticeNumber": {
-            "type": "string"
+          "dateTo" : {
+            "$ref" : "#/components/schemas/LocalDate"
           },
-          "creditorReferenceId": {
-            "type": "string"
+          "count" : {
+            "format" : "int32",
+            "type" : "integer"
           },
-          "paymentToken": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "insertedTimestamp": {
-            "$ref": "#/components/schemas/Instant"
-          },
-          "updatedTimestamp": {
-            "$ref": "#/components/schemas/Instant"
-          },
-          "insertedBy": {
-            "type": "string"
-          },
-          "updatedBy": {
-            "type": "string"
-          },
-          "serviceIdentifier": {
-            "type": "string"
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentInfo"
+            }
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable",
-            "type": "string"
+      "PositionPaymentSSInfo" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "status": {
-            "format": "int32",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "example": 200
+          "noticeNumber" : {
+            "type" : "string"
           },
-          "details": {
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "type": "string",
-            "example": "There was an error processing the request"
+          "creditorReferenceId" : {
+            "type" : "string"
+          },
+          "paymentToken" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "insertedTimestamp" : {
+            "$ref" : "#/components/schemas/Instant"
+          },
+          "updatedTimestamp" : {
+            "$ref" : "#/components/schemas/Instant"
+          },
+          "insertedBy" : {
+            "type" : "string"
+          },
+          "updatedBy" : {
+            "type" : "string"
+          },
+          "serviceIdentifier" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PositionPaymentSnapshotDto" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "pa_fiscal_code" : {
+            "type" : "string"
+          },
+          "notice_id" : {
+            "type" : "string"
+          },
+          "creditor_reference_id" : {
+            "type" : "string"
+          },
+          "payment_token" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "inserted_timestamp" : {
+            "$ref" : "#/components/schemas/Instant"
+          },
+          "updated_timestamp" : {
+            "$ref" : "#/components/schemas/Instant"
+          },
+          "fk_position_payment" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "inserted_by" : {
+            "type" : "string"
+          },
+          "updated_by" : {
+            "type" : "string"
+          }
+        }
+      },
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable",
+            "type" : "string"
+          },
+          "status" : {
+            "format" : "int32",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "example" : 200
+          },
+          "details" : {
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "type" : "string",
+            "example" : "There was an error processing the request"
           }
         }
       }
     },
-    "securitySchemes": {
-      "SecurityScheme": {
-        "type": "http",
-        "description": "Authentication",
-        "scheme": "basic"
+    "securitySchemes" : {
+      "SecurityScheme" : {
+        "type" : "http",
+        "description" : "Authentication",
+        "scheme" : "basic"
       }
     }
   }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Node technical support - API (local) ${service}",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.21"
+    "version": "1.2.22"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,56 +1,64 @@
 {
-  "openapi" : "3.0.3",
-  "info" : {
-    "title" : "Node technical support - API (local) ${service}",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "1.2.22-1-PIDM-1117-status-recovery"
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Node technical support - API (local) ${service}",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "1.2.22-2-PIDM-1117-status-recovery"
   },
-  "servers" : [ {
-    "url" : "${host}/technical-support/nodo/api/v1"
-  } ],
-  "tags" : [ {
-    "name" : "Info",
-    "description" : "Info operations"
-  } ],
-  "paths" : {
-    "/events/negative/{bizEventId}" : {
-      "get" : {
-        "tags" : [ "Events Resource" ],
-        "parameters" : [ {
-          "name" : "bizEventId",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+  "servers": [
+    {
+      "url": "${host}/technical-support/nodo/api/v1"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Info",
+      "description": "Info operations"
+    }
+  ],
+  "paths": {
+    "/events/negative/{bizEventId}": {
+      "get": {
+        "tags": [
+          "Events Resource"
+        ],
+        "parameters": [
+          {
+            "name": "bizEventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsFullResponse"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsFullResponse"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -58,17 +66,19 @@
         }
       }
     },
-    "/info" : {
-      "get" : {
-        "tags" : [ "Info" ],
-        "summary" : "Get info of Node tech support API",
-        "responses" : {
-          "200" : {
-            "description" : "Success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/InfoResponse"
+    "/info": {
+      "get": {
+        "tags": [
+          "Info"
+        ],
+        "summary": "Get info of Node tech support API",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InfoResponse"
                 }
               }
             }
@@ -76,63 +86,70 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/iuv/{iuv}" : {
-      "get" : {
-        "tags" : [ "Worker Resource" ],
-        "parameters" : [ {
-          "name" : "iuv",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationFiscalCode}/iuv/{iuv}": {
+      "get": {
+        "tags": [
+          "Worker Resource"
+        ],
+        "parameters": [
+          {
+            "name": "iuv",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "organizationFiscalCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
           }
-        }, {
-          "name" : "organizationFiscalCode",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "dateFrom",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        }, {
-          "name" : "dateTo",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsResponse"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -140,70 +157,78 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/iuv/{iuv}/ccp/{ccp}" : {
-      "get" : {
-        "tags" : [ "Worker Resource" ],
-        "parameters" : [ {
-          "name" : "ccp",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationFiscalCode}/iuv/{iuv}/ccp/{ccp}": {
+      "get": {
+        "tags": [
+          "Worker Resource"
+        ],
+        "parameters": [
+          {
+            "name": "ccp",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "organizationFiscalCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
           }
-        }, {
-          "name" : "iuv",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "organizationFiscalCode",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "dateFrom",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        }, {
-          "name" : "dateTo",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsFullResponse"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsFullResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -211,63 +236,70 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}" : {
-      "get" : {
-        "tags" : [ "Worker Resource" ],
-        "parameters" : [ {
-          "name" : "noticeNumber",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}": {
+      "get": {
+        "tags": [
+          "Worker Resource"
+        ],
+        "parameters": [
+          {
+            "name": "noticeNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "organizationFiscalCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
           }
-        }, {
-          "name" : "organizationFiscalCode",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "dateFrom",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        }, {
-          "name" : "dateTo",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsResponse"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -275,70 +307,78 @@
         }
       }
     },
-    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}/paymentToken/{paymentToken}" : {
-      "get" : {
-        "tags" : [ "Worker Resource" ],
-        "parameters" : [ {
-          "name" : "noticeNumber",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationFiscalCode}/noticeNumber/{noticeNumber}/paymentToken/{paymentToken}": {
+      "get": {
+        "tags": [
+          "Worker Resource"
+        ],
+        "parameters": [
+          {
+            "name": "noticeNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "organizationFiscalCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "paymentToken",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
           }
-        }, {
-          "name" : "organizationFiscalCode",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "paymentToken",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "dateFrom",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        }, {
-          "name" : "dateTo",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsFullResponse"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsFullResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -346,30 +386,35 @@
         }
       }
     },
-    "/paymentToken/{paymentToken}" : {
-      "get" : {
-        "tags" : [ "Position Payment Snapshot Resource" ],
-        "parameters" : [ {
-          "name" : "paymentToken",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/paymentToken/{paymentToken}": {
+      "get": {
+        "tags": [
+          "Position Payment Snapshot Resource"
+        ],
+        "parameters": [
+          {
+            "name": "paymentToken",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "serviceIdentifier",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "serviceIdentifier",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PositionPaymentSnapshotDto"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PositionPaymentSnapshotDto"
                 }
               }
             }
@@ -377,86 +422,96 @@
         }
       }
     },
-    "/snapshot/organizations/{organizationFiscalCode}" : {
-      "get" : {
-        "tags" : [ "Snapshot Resource" ],
-        "parameters" : [ {
-          "name" : "organizationFiscalCode",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/snapshot/organizations/{organizationFiscalCode}": {
+      "get": {
+        "tags": [
+          "Snapshot Resource"
+        ],
+        "parameters": [
+          {
+            "name": "organizationFiscalCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LocalDate"
+            }
+          },
+          {
+            "name": "noticeNumber",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "format": "int64",
+              "default": 1,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "name": "paymentToken",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "schema": {
+              "format": "int64",
+              "default": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
           }
-        }, {
-          "name" : "dateFrom",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        }, {
-          "name" : "dateTo",
-          "in" : "query",
-          "schema" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          }
-        }, {
-          "name" : "noticeNumber",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "schema" : {
-            "format" : "int64",
-            "default" : 1,
-            "minimum" : 1,
-            "type" : "integer"
-          }
-        }, {
-          "name" : "paymentToken",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "schema" : {
-            "format" : "int64",
-            "default" : 1000,
-            "minimum" : 1,
-            "type" : "integer"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentResponse"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
@@ -465,407 +520,412 @@
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "ErrorCode" : {
-        "type" : "object",
-        "properties" : {
-          "code" : {
-            "type" : "string",
-            "example" : "0500"
+  "components": {
+    "schemas": {
+      "ErrorCode": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "0500"
           },
-          "description" : {
-            "type" : "string",
-            "example" : "An unexpected error has occurred. Please contact support."
+          "description": {
+            "type": "string",
+            "example": "An unexpected error has occurred. Please contact support."
           },
-          "statusCode" : {
-            "format" : "int32",
-            "type" : "integer",
-            "example" : 500
+          "statusCode": {
+            "format": "int32",
+            "type": "integer",
+            "example": 500
           }
         }
       },
-      "FaultBean" : {
-        "type" : "object",
-        "properties" : {
-          "faultCode" : {
-            "type" : "string"
+      "FaultBean": {
+        "type": "object",
+        "properties": {
+          "faultCode": {
+            "type": "string"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "timestamp" : {
-            "type" : "string"
+          "timestamp": {
+            "type": "string"
           }
         }
       },
-      "InfoResponse" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "example" : "pagopa-node-tech-support"
+      "InfoResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "pagopa-node-tech-support"
           },
-          "version" : {
-            "type" : "string",
-            "example" : "1.2.3"
+          "version": {
+            "type": "string",
+            "example": "1.2.3"
           },
-          "environment" : {
-            "type" : "string",
-            "example" : "dev"
+          "environment": {
+            "type": "string",
+            "example": "dev"
           },
-          "description" : {
-            "type" : "string",
-            "example" : "Node tech support API"
+          "description": {
+            "type": "string",
+            "example": "Node tech support API"
           },
-          "errorCodes" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/ErrorCode"
+          "errorCodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorCode"
             }
           }
         }
       },
-      "Instant" : {
-        "format" : "date-time",
-        "type" : "string",
-        "example" : "2022-03-10T16:15:50Z"
+      "Instant": {
+        "format": "date-time",
+        "type": "string",
+        "example": "2022-03-10T16:15:50Z"
       },
-      "LocalDate" : {
-        "format" : "date",
-        "type" : "string",
-        "example" : "2022-03-10"
+      "LocalDate": {
+        "format": "date",
+        "type": "string",
+        "example": "2022-03-10"
       },
-      "Metadata" : {
-        "type" : "object",
-        "properties" : {
-          "pageSize" : {
-            "format" : "int32",
-            "type" : "integer",
-            "example" : 25
+      "Metadata": {
+        "type": "object",
+        "properties": {
+          "pageSize": {
+            "format": "int32",
+            "type": "integer",
+            "example": 25
           },
-          "pageNumber" : {
-            "format" : "int32",
-            "type" : "integer",
-            "example" : 1
+          "pageNumber": {
+            "format": "int32",
+            "type": "integer",
+            "example": 1
           },
-          "totPage" : {
-            "format" : "int32",
-            "type" : "integer",
-            "example" : 3
+          "totPage": {
+            "format": "int32",
+            "type": "integer",
+            "example": 3
           }
         }
       },
-      "PaymentFullInfo" : {
-        "type" : "object",
-        "properties" : {
-          "businessProcess" : {
-            "type" : "string"
+      "PaymentFullInfo": {
+        "type": "object",
+        "properties": {
+          "businessProcess": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "noticeNumber" : {
-            "type" : "string"
+          "noticeNumber": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "pspId" : {
-            "type" : "string"
+          "pspId": {
+            "type": "string"
           },
-          "brokerPspId" : {
-            "type" : "string"
+          "brokerPspId": {
+            "type": "string"
           },
-          "channelId" : {
-            "type" : "string"
+          "channelId": {
+            "type": "string"
           },
-          "outcome" : {
-            "type" : "string"
+          "outcome": {
+            "type": "string"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/PaymentStatus"
+          "status": {
+            "$ref": "#/components/schemas/PaymentStatus"
           },
-          "insertedTimestamp" : {
-            "type" : "string"
+          "insertedTimestamp": {
+            "type": "string"
           },
-          "serviceIdentifier" : {
-            "type" : "string"
+          "serviceIdentifier": {
+            "type": "string"
           },
-          "paymentToken" : {
-            "type" : "string"
+          "paymentToken": {
+            "type": "string"
           },
-          "ccp" : {
-            "type" : "string"
+          "ccp": {
+            "type": "string"
           },
-          "positiveBizEvtId" : {
-            "type" : "string"
+          "positiveBizEvtId": {
+            "type": "string"
           },
-          "verifyKoEvtId" : {
-            "type" : "string"
+          "verifyKoEvtId": {
+            "type": "string"
           },
-          "negativeBizEvtId" : {
-            "type" : "string"
+          "negativeBizEvtId": {
+            "type": "string"
           },
-          "faultBean" : {
-            "$ref" : "#/components/schemas/FaultBean"
+          "faultBean": {
+            "$ref": "#/components/schemas/FaultBean"
           },
-          "brokerOrganizationId" : {
-            "type" : "string"
+          "brokerOrganizationId": {
+            "type": "string"
           },
-          "stationId" : {
-            "type" : "string"
+          "stationId": {
+            "type": "string"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "number"
+          "amount": {
+            "type": "number"
           },
-          "pmReceipt" : {
-            "type" : "string"
+          "pmReceipt": {
+            "type": "string"
           },
-          "touchPoint" : {
-            "type" : "string"
+          "touchPoint": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "number"
+          "fee": {
+            "type": "number"
           },
-          "feeOrganization" : {
-            "type" : "number"
+          "feeOrganization": {
+            "type": "number"
           }
         }
       },
-      "PaymentInfo" : {
-        "type" : "object",
-        "properties" : {
-          "businessProcess" : {
-            "type" : "string"
+      "PaymentInfo": {
+        "type": "object",
+        "properties": {
+          "businessProcess": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "noticeNumber" : {
-            "type" : "string"
+          "noticeNumber": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "pspId" : {
-            "type" : "string"
+          "pspId": {
+            "type": "string"
           },
-          "brokerPspId" : {
-            "type" : "string"
+          "brokerPspId": {
+            "type": "string"
           },
-          "channelId" : {
-            "type" : "string"
+          "channelId": {
+            "type": "string"
           },
-          "outcome" : {
-            "type" : "string"
+          "outcome": {
+            "type": "string"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/PaymentStatus"
+          "status": {
+            "$ref": "#/components/schemas/PaymentStatus"
           },
-          "insertedTimestamp" : {
-            "type" : "string"
+          "insertedTimestamp": {
+            "type": "string"
           },
-          "serviceIdentifier" : {
-            "type" : "string"
+          "serviceIdentifier": {
+            "type": "string"
           },
-          "paymentToken" : {
-            "type" : "string"
+          "paymentToken": {
+            "type": "string"
           },
-          "ccp" : {
-            "type" : "string"
+          "ccp": {
+            "type": "string"
           },
-          "positiveBizEvtId" : {
-            "type" : "string"
+          "positiveBizEvtId": {
+            "type": "string"
           },
-          "verifyKoEvtId" : {
-            "type" : "string"
+          "verifyKoEvtId": {
+            "type": "string"
           },
-          "negativeBizEvtId" : {
-            "type" : "string"
+          "negativeBizEvtId": {
+            "type": "string"
           },
-          "faultBean" : {
-            "$ref" : "#/components/schemas/FaultBean"
+          "faultBean": {
+            "$ref": "#/components/schemas/FaultBean"
           }
         }
       },
-      "PaymentResponse" : {
-        "type" : "object",
-        "properties" : {
-          "metadata" : {
-            "$ref" : "#/components/schemas/Metadata"
+      "PaymentResponse": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/Metadata"
           },
-          "count" : {
-            "format" : "int64",
-            "type" : "integer",
-            "example" : 100
+          "count": {
+            "format": "int64",
+            "type": "integer",
+            "example": 100
           },
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PositionPaymentSSInfo"
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PositionPaymentSSInfo"
             }
           },
-          "dateFrom" : {
-            "$ref" : "#/components/schemas/LocalDate"
+          "dateFrom": {
+            "$ref": "#/components/schemas/LocalDate"
           },
-          "dateTo" : {
-            "$ref" : "#/components/schemas/LocalDate"
+          "dateTo": {
+            "$ref": "#/components/schemas/LocalDate"
           }
         }
       },
-      "PaymentStatus" : {
-        "enum" : [ "completed", "failed", "cancelled", "unknown" ],
-        "type" : "string"
+      "PaymentStatus": {
+        "enum": [
+          "completed",
+          "failed",
+          "cancelled",
+          "unknown"
+        ],
+        "type": "string"
       },
-      "PaymentsFullResponse" : {
-        "type" : "object",
-        "properties" : {
-          "dateFrom" : {
-            "$ref" : "#/components/schemas/LocalDate"
+      "PaymentsFullResponse": {
+        "type": "object",
+        "properties": {
+          "dateFrom": {
+            "$ref": "#/components/schemas/LocalDate"
           },
-          "dateTo" : {
-            "$ref" : "#/components/schemas/LocalDate"
+          "dateTo": {
+            "$ref": "#/components/schemas/LocalDate"
           },
-          "count" : {
-            "format" : "int32",
-            "type" : "integer"
+          "count": {
+            "format": "int32",
+            "type": "integer"
           },
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentFullInfo"
-            }
-          }
-        }
-      },
-      "PaymentsResponse" : {
-        "type" : "object",
-        "properties" : {
-          "dateFrom" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          },
-          "dateTo" : {
-            "$ref" : "#/components/schemas/LocalDate"
-          },
-          "count" : {
-            "format" : "int32",
-            "type" : "integer"
-          },
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentInfo"
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentFullInfo"
             }
           }
         }
       },
-      "PositionPaymentSSInfo" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
+      "PaymentsResponse": {
+        "type": "object",
+        "properties": {
+          "dateFrom": {
+            "$ref": "#/components/schemas/LocalDate"
           },
-          "noticeNumber" : {
-            "type" : "string"
+          "dateTo": {
+            "$ref": "#/components/schemas/LocalDate"
           },
-          "creditorReferenceId" : {
-            "type" : "string"
+          "count": {
+            "format": "int32",
+            "type": "integer"
           },
-          "paymentToken" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string"
-          },
-          "insertedTimestamp" : {
-            "$ref" : "#/components/schemas/Instant"
-          },
-          "updatedTimestamp" : {
-            "$ref" : "#/components/schemas/Instant"
-          },
-          "insertedBy" : {
-            "type" : "string"
-          },
-          "updatedBy" : {
-            "type" : "string"
-          },
-          "serviceIdentifier" : {
-            "type" : "string"
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentInfo"
+            }
           }
         }
       },
-      "PositionPaymentSnapshotDto" : {
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "format" : "int64",
-            "type" : "integer"
+      "PositionPaymentSSInfo": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "pa_fiscal_code" : {
-            "type" : "string"
+          "noticeNumber": {
+            "type": "string"
           },
-          "notice_id" : {
-            "type" : "string"
+          "creditorReferenceId": {
+            "type": "string"
           },
-          "creditor_reference_id" : {
-            "type" : "string"
+          "paymentToken": {
+            "type": "string"
           },
-          "payment_token" : {
-            "type" : "string"
+          "status": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string"
+          "insertedTimestamp": {
+            "$ref": "#/components/schemas/Instant"
           },
-          "inserted_timestamp" : {
-            "$ref" : "#/components/schemas/Instant"
+          "updatedTimestamp": {
+            "$ref": "#/components/schemas/Instant"
           },
-          "updated_timestamp" : {
-            "$ref" : "#/components/schemas/Instant"
+          "insertedBy": {
+            "type": "string"
           },
-          "fk_position_payment" : {
-            "format" : "int64",
-            "type" : "integer"
+          "updatedBy": {
+            "type": "string"
           },
-          "inserted_by" : {
-            "type" : "string"
-          },
-          "updated_by" : {
-            "type" : "string"
+          "serviceIdentifier": {
+            "type": "string"
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable",
-            "type" : "string"
+      "PositionPaymentSnapshotDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
           },
-          "status" : {
-            "format" : "int32",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "example" : 200
+          "pa_fiscal_code": {
+            "type": "string"
           },
-          "details" : {
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "type" : "string",
-            "example" : "There was an error processing the request"
+          "notice_id": {
+            "type": "string"
+          },
+          "creditor_reference_id": {
+            "type": "string"
+          },
+          "payment_token": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "inserted_timestamp": {
+            "$ref": "#/components/schemas/Instant"
+          },
+          "updated_timestamp": {
+            "$ref": "#/components/schemas/Instant"
+          },
+          "fk_position_payment": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "inserted_by": {
+            "type": "string"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable",
+            "type": "string"
+          },
+          "status": {
+            "format": "int32",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "example": 200
+          },
+          "details": {
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "type": "string",
+            "example": "There was an error processing the request"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "SecurityScheme" : {
-        "type" : "http",
-        "description" : "Authentication",
-        "scheme" : "basic"
+    "securitySchemes": {
+      "SecurityScheme": {
+        "type": "http",
+        "description": "Authentication",
+        "scheme": "basic"
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.gov.pagopa</groupId>
   <artifactId>node-techical-support-worker</artifactId>
-  <version>1.2.21</version>
+  <version>1.2.22</version>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <lombok.version>1.18.26</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.gov.pagopa</groupId>
   <artifactId>node-techical-support-worker</artifactId>
-  <version>1.2.22</version>
+  <version>1.2.22-1-PIDM-1117-status-recovery</version>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <lombok.version>1.18.26</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.gov.pagopa</groupId>
   <artifactId>node-techical-support-worker</artifactId>
-  <version>1.2.22-1-PIDM-1117-status-recovery</version>
+  <version>1.2.22-2-PIDM-1117-status-recovery</version>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <lombok.version>1.18.26</lombok.version>

--- a/src/main/java/it/gov/pagopa/nodetsworker/models/PaymentInfo.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/models/PaymentInfo.java
@@ -1,6 +1,8 @@
 package it.gov.pagopa.nodetsworker.models;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import it.gov.pagopa.nodetsworker.models.enums.PaymentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +18,6 @@ public class PaymentInfo {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String businessProcess;
-//  private String paymentStatus;
 
   private String organizationFiscalCode;
   private String noticeNumber;
@@ -25,9 +26,8 @@ public class PaymentInfo {
   private String brokerPspId;
   private String channelId;
   private String outcome;
-  private String status;
+  private PaymentStatus status;
   private String insertedTimestamp;
-//  private String updatedTimestamp;
   private String serviceIdentifier;
 
   private String paymentToken;

--- a/src/main/java/it/gov/pagopa/nodetsworker/models/PositionPaymentSnapshotDto.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/models/PositionPaymentSnapshotDto.java
@@ -1,0 +1,43 @@
+package it.gov.pagopa.nodetsworker.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.Instant;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Builder
+public class PositionPaymentSnapshotDto {
+
+    private Long id;
+
+    @JsonProperty("pa_fiscal_code")
+    private String paFiscalCode;
+
+    @JsonProperty("notice_id")
+    private String noticeId;
+
+    @JsonProperty("creditor_reference_id")
+    private String creditorReferenceId;
+
+    @JsonProperty("payment_token")
+    private String paymentToken;
+
+    private String status;
+
+    @JsonProperty("inserted_timestamp")
+    private Instant insertedTimestamp;
+
+    @JsonProperty("updated_timestamp")
+    private Instant updatedTimestamp;
+
+    @JsonProperty("fk_position_payment")
+    private Long fkPositionPayment;
+
+    @JsonProperty("inserted_by")
+    private String insertedBy;
+
+    @JsonProperty("updated_by")
+    private String updatedBy;
+}

--- a/src/main/java/it/gov/pagopa/nodetsworker/models/enums/PaymentStatus.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/models/enums/PaymentStatus.java
@@ -1,0 +1,16 @@
+package it.gov.pagopa.nodetsworker.models.enums;
+
+public enum PaymentStatus {
+    COMPLETED("completed"),
+    FAILED("failed"),
+    CANCELLED("cancelled"),
+    UNKNOWN("unknown");
+
+    private final String value;
+
+    PaymentStatus(String value) { this.value = value; }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+}
+

--- a/src/main/java/it/gov/pagopa/nodetsworker/repository/CosmosClientsConfig.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/repository/CosmosClientsConfig.java
@@ -31,7 +31,7 @@ class CosmosClientsConfig {
     /**
      * Preferred region for Cosmos DB client.
      * If set, the client will try this region first (read/write) and fallback to others if needed.
-     * Only for prod environment the property is expected to be set.
+     * For prod environment the property is expected to be set to replica region, to avoid performance issues on the primary region.
      */
     @ConfigProperty(name = "cosmos.preferred.region")
     Optional<String> preferredRegion;

--- a/src/main/java/it/gov/pagopa/nodetsworker/repository/PositionPaymentSSRepository.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/repository/PositionPaymentSSRepository.java
@@ -1,0 +1,33 @@
+package it.gov.pagopa.nodetsworker.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import it.gov.pagopa.nodetsworker.repository.models.PositionPaymentSSEntity;
+import it.gov.pagopa.nodetsworker.repository.qualifiers.DefaultNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@ApplicationScoped
+@DefaultNode
+public class PositionPaymentSSRepository implements PositionPaymentSnapshotReader{
+
+	@PersistenceContext
+	EntityManager em;
+
+	@Override
+	public Optional<PositionPaymentSSEntity> findByPaymentToken(String paymentToken) {
+		List<PositionPaymentSSEntity> res = em.createQuery("""
+				    SELECT p
+				    FROM PositionPaymentSSEntity p
+				    WHERE p.paymentToken = :token
+				    ORDER BY p.id DESC
+				""", PositionPaymentSSEntity.class)
+				.setParameter("token", paymentToken)
+				.setMaxResults(1)
+				.getResultList();
+
+		return res.stream().findFirst();
+	}
+}

--- a/src/main/java/it/gov/pagopa/nodetsworker/repository/PositionPaymentSnapshotReader.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/repository/PositionPaymentSnapshotReader.java
@@ -1,0 +1,9 @@
+package it.gov.pagopa.nodetsworker.repository;
+
+import it.gov.pagopa.nodetsworker.repository.models.PositionPaymentSSEntity;
+
+import java.util.Optional;
+
+public interface PositionPaymentSnapshotReader {
+    Optional<PositionPaymentSSEntity> findByPaymentToken(String paymentToken);
+}

--- a/src/main/java/it/gov/pagopa/nodetsworker/repository/qualifiers/DefaultNode.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/repository/qualifiers/DefaultNode.java
@@ -1,0 +1,14 @@
+package it.gov.pagopa.nodetsworker.repository.qualifiers;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, FIELD, METHOD, PARAMETER})
+public @interface DefaultNode {}

--- a/src/main/java/it/gov/pagopa/nodetsworker/resources/InfoResource.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/resources/InfoResource.java
@@ -1,5 +1,6 @@
-package it.gov.pagopa.nodetsworker.exceptions;
+package it.gov.pagopa.nodetsworker.resources;
 
+import it.gov.pagopa.nodetsworker.exceptions.AppErrorCodeMessageEnum;
 import it.gov.pagopa.nodetsworker.resources.response.InfoResponse;
 import it.gov.pagopa.nodetsworker.util.AppMessageUtil;
 import jakarta.inject.Inject;

--- a/src/main/java/it/gov/pagopa/nodetsworker/resources/PositionPaymentSnapshotResource.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/resources/PositionPaymentSnapshotResource.java
@@ -1,0 +1,24 @@
+package it.gov.pagopa.nodetsworker.resources;
+
+import it.gov.pagopa.nodetsworker.models.PositionPaymentSnapshotDto;
+import it.gov.pagopa.nodetsworker.service.PositionPaymentSnapshotService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/paymentToken")
+@Produces(MediaType.APPLICATION_JSON)
+public class PositionPaymentSnapshotResource {
+
+    @Inject
+    PositionPaymentSnapshotService service;
+
+    @GET
+    @Path("/{paymentToken}")
+    public PositionPaymentSnapshotDto getByPaymentToken(
+            @PathParam("paymentToken") String paymentToken,
+            @QueryParam("serviceIdentifier") String serviceIdentifier
+    ) {
+        return service.getByPaymentToken(paymentToken, serviceIdentifier);
+    }
+}

--- a/src/main/java/it/gov/pagopa/nodetsworker/service/NodeSnapshotRouter.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/service/NodeSnapshotRouter.java
@@ -1,0 +1,30 @@
+package it.gov.pagopa.nodetsworker.service;
+
+import it.gov.pagopa.nodetsworker.repository.PositionPaymentSnapshotReader;
+import it.gov.pagopa.nodetsworker.repository.qualifiers.DefaultNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class NodeSnapshotRouter {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    @DefaultNode
+    PositionPaymentSnapshotReader defaultReader;
+
+    public PositionPaymentSnapshotReader resolve(String serviceIdentifier) {
+        // Multi-node setup:
+    	// - today: always returns default reader, as we have only one node
+    	// - in the future: logic to determine the correct reader based on serviceIdentifier 
+    	//   (e.g., mapping serviceIdentifier -> nodeKey in application.properties, like snapshot.node-map.NDP003PROD=default etc.)
+        if (serviceIdentifier == null || serviceIdentifier.isBlank()) {
+            return defaultReader;
+        }
+        
+        return defaultReader;
+    }
+}

--- a/src/main/java/it/gov/pagopa/nodetsworker/service/PositionPaymentSnapshotService.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/service/PositionPaymentSnapshotService.java
@@ -1,0 +1,39 @@
+package it.gov.pagopa.nodetsworker.service;
+
+import it.gov.pagopa.nodetsworker.exceptions.AppErrorCodeMessageEnum;
+import it.gov.pagopa.nodetsworker.exceptions.AppException;
+import it.gov.pagopa.nodetsworker.models.PositionPaymentSnapshotDto;
+import it.gov.pagopa.nodetsworker.repository.PositionPaymentSnapshotReader;
+import it.gov.pagopa.nodetsworker.repository.models.PositionPaymentSSEntity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class PositionPaymentSnapshotService {
+
+    @Inject
+    NodeSnapshotRouter router;
+
+    public PositionPaymentSnapshotDto getByPaymentToken(String paymentToken, String serviceIdentifier) {
+
+        PositionPaymentSnapshotReader reader = router.resolve(serviceIdentifier);
+
+        PositionPaymentSSEntity e = reader.findByPaymentToken(paymentToken)
+                .orElseThrow(() -> new AppException(AppErrorCodeMessageEnum.NOT_FOUND,
+                        "No snapshot row found for paymentToken %s", paymentToken));
+
+        return PositionPaymentSnapshotDto.builder()
+                .id(e.getId())
+                .paFiscalCode(e.getPaFiscalCode())
+                .noticeId(e.getNoticeId())
+                .creditorReferenceId(e.getCreditorReferenceId())
+                .paymentToken(e.getPaymentToken())
+                .status(e.getStatus())
+                .insertedTimestamp(e.getInsertedTimestamp())
+                .updatedTimestamp(e.getUpdatedTimestamp())
+                .fkPositionPayment(e.getFkPositionPayment())
+                .insertedBy(e.getInsertedBy())
+                .updatedBy(e.getUpdatedBY())
+                .build();
+    }
+}

--- a/src/main/java/it/gov/pagopa/nodetsworker/service/WorkerService.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/service/WorkerService.java
@@ -360,4 +360,17 @@ public class WorkerService {
                         () -> new AppException(AppErrorCodeMessageEnum.NOT_FOUND, "No negative biz event with id %s", bizEventId)
                 );
     }
+    
+    private PaymentStatus mapNegativeStatus(String businessProcess) {
+        if (businessProcess == null) {
+            return PaymentStatus.CANCELLED;
+        }
+        if (BP_FAILED.contains(businessProcess)) {
+            return PaymentStatus.FAILED;
+        }
+        if (BP_UNKNOWN.contains(businessProcess)) {
+            return PaymentStatus.UNKNOWN;
+        }
+        return PaymentStatus.CANCELLED;
+    }
 }

--- a/src/main/java/it/gov/pagopa/nodetsworker/service/WorkerService.java
+++ b/src/main/java/it/gov/pagopa/nodetsworker/service/WorkerService.java
@@ -25,15 +25,25 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static it.gov.pagopa.nodetsworker.util.AppConstant.SERVICE_ID;
-import static it.gov.pagopa.nodetsworker.util.AppConstant.STATUS_COMPLETED;
+import it.gov.pagopa.nodetsworker.models.enums.PaymentStatus;
 
 @ApplicationScoped
 public class WorkerService {
 
     private static final String OUTCOME_OK = "OK";
     private static final String OUTCOME_KO = "KO";
+    private static final Set<String> BP_FAILED = Set.of(
+            "sendPaymentOutcome",
+            "sendPaymentOutcomeV2"
+    );
+
+    private static final Set<String> BP_UNKNOWN = Set.of(
+            "nodoInviaRT",
+            "rtPullRecoveryPush"
+    );
 
     @Inject
     Logger log;
@@ -51,6 +61,7 @@ public class WorkerService {
 
         return PaymentInfo.builder()
                 .businessProcess("VerifyPaymentNotice")
+                .status(PaymentStatus.FAILED)
                 .serviceIdentifier(evt.getServiceIdentifier())
                 .pspId(evt.getPsp().getIdPsp())
                 .verifyKoEvtId(evt.getId())
@@ -67,7 +78,7 @@ public class WorkerService {
 
     private PaymentInfo eventToPaymentInfo(PositiveBizEvent evt) {
         return PaymentInfo.builder()
-                .status(STATUS_COMPLETED)
+                .status(PaymentStatus.COMPLETED)
                 .serviceIdentifier(evt.getProperties()!=null?evt.getProperties().get(SERVICE_ID):"n/a")
                 .pspId(evt.getPsp().getIdPsp())
                 .positiveBizEvtId(evt.getId())
@@ -85,7 +96,7 @@ public class WorkerService {
 
     private PaymentFullInfo eventToPaymentFullInfo(PositiveBizEvent evt) {
         return PaymentFullInfo.builder()
-                .status(STATUS_COMPLETED)
+        		.status(PaymentStatus.COMPLETED)
                 .serviceIdentifier(evt.getProperties()!=null?evt.getProperties().get(SERVICE_ID):"n/a")
                 .pspId(evt.getPsp().getIdPsp())
                 .positiveBizEvtId(evt.getId())
@@ -106,6 +117,7 @@ public class WorkerService {
     private PaymentInfo eventToPaymentInfo(NegativeBizEvent evt) {
         return PaymentInfo.builder()
                 .businessProcess(evt.getBusinessProcess())
+                .status(mapNegativeStatus(evt.getBusinessProcess()))
                 .serviceIdentifier(evt.getProperties()!=null?evt.getProperties().get(SERVICE_ID):"n/a")
                 .pspId(evt.getPsp().getIdPsp())
                 .negativeBizEvtId(evt.getId())
@@ -124,6 +136,7 @@ public class WorkerService {
     private PaymentFullInfo eventToPaymentFullInfo(NegativeBizEvent evt) {
         return PaymentFullInfo.builder()
                 .businessProcess(evt.getBusinessProcess())
+                .status(mapNegativeStatus(evt.getBusinessProcess()))
                 .serviceIdentifier(evt.getProperties()!=null?evt.getProperties().get(SERVICE_ID):"n/a")
                 .pspId(evt.getPsp().getIdPsp())
                 .negativeBizEvtId(evt.getId())
@@ -332,5 +345,18 @@ public class WorkerService {
                 .orElseThrow(
                         () -> new AppException(AppErrorCodeMessageEnum.NOT_FOUND, "No negative biz event with id %s", bizEventId)
                 );
+    }
+    
+    private PaymentStatus mapNegativeStatus(String businessProcess) {
+        if (businessProcess == null) {
+            return PaymentStatus.CANCELLED;
+        }
+        if (BP_FAILED.contains(businessProcess)) {
+            return PaymentStatus.FAILED;
+        }
+        if (BP_UNKNOWN.contains(businessProcess)) {
+            return PaymentStatus.UNKNOWN;
+        }
+        return PaymentStatus.CANCELLED;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -99,7 +99,7 @@ bizneg.endpoint=${COSMOS_NEG_BIZ_ENDPOINT:${mockserver.cosmos.endpoint}}
 bizneg.key=${COSMOS_NEG_BIZ_KEY:${mockserver.cosmos.key}}
 verifyko.endpoint=${COSMOS_VERIFYKO_ENDPOINT:${mockserver.cosmos.endpoint}}
 verifyko.key=${COSMOS_VERIFYKO_KEY:${mockserver.cosmos.key}}
-%prod.cosmos.preferred.region=${COSMOS_PREFERRED_REGION:North Europe}
+cosmos.preferred.region=${COSMOS_PREFERRED_REGION:West Europe}
 
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -90,14 +90,18 @@ quarkus.hibernate-orm.validate-in-dev-mode=false
 %test.quarkus.hibernate-orm.log.sql=true
 %test.quarkus.hibernate-orm.database.generation=drop-and-create
 
-
-
+###################
+## COSMOS DB
+###################
 biz.endpoint=${COSMOS_BIZ_ENDPOINT:${mockserver.cosmos.endpoint}}
 biz.key=${COSMOS_BIZ_KEY:${mockserver.cosmos.key}}
 bizneg.endpoint=${COSMOS_NEG_BIZ_ENDPOINT:${mockserver.cosmos.endpoint}}
 bizneg.key=${COSMOS_NEG_BIZ_KEY:${mockserver.cosmos.key}}
 verifyko.endpoint=${COSMOS_VERIFYKO_ENDPOINT:${mockserver.cosmos.endpoint}}
 verifyko.key=${COSMOS_VERIFYKO_KEY:${mockserver.cosmos.key}}
+%prod.cosmos.preferred.region=North Europe
+
+
 
 %openapi.biz.endpoint=nn
 %openapi.biz.key=nn
@@ -126,3 +130,5 @@ quarkus.test.continuous-testing=disabled
 quarkus.http.test-port=8083
 
 %test.quarkus.micrometer.enabled=false
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -124,3 +124,5 @@ operations.filter=".*"
 
 quarkus.test.continuous-testing=disabled
 quarkus.http.test-port=8083
+
+%test.quarkus.micrometer.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -99,7 +99,7 @@ bizneg.endpoint=${COSMOS_NEG_BIZ_ENDPOINT:${mockserver.cosmos.endpoint}}
 bizneg.key=${COSMOS_NEG_BIZ_KEY:${mockserver.cosmos.key}}
 verifyko.endpoint=${COSMOS_VERIFYKO_ENDPOINT:${mockserver.cosmos.endpoint}}
 verifyko.key=${COSMOS_VERIFYKO_KEY:${mockserver.cosmos.key}}
-%prod.cosmos.preferred.region=North Europe
+%prod.cosmos.preferred.region=${COSMOS_PREFERRED_REGION:North Europe}
 
 
 

--- a/src/test/java/it/gov/pagopa/nodetsworker/repository/CosmosClientsConfigTest.java
+++ b/src/test/java/it/gov/pagopa/nodetsworker/repository/CosmosClientsConfigTest.java
@@ -1,0 +1,158 @@
+package it.gov.pagopa.nodetsworker.repository;
+
+import com.azure.cosmos.CosmosClient;
+import com.azure.cosmos.CosmosClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class CosmosClientsConfigTest {
+
+    @Test
+    void shouldNotSetPreferredRegion_whenOptionalIsEmpty() throws Exception {
+        CosmosClientsConfig cfg = baseConfig(Optional.empty());
+
+        try (MockedConstruction<CosmosClientBuilder> mocked = mockConstruction(
+                CosmosClientBuilder.class,
+                (builder, context) -> {
+                    when(builder.endpoint(anyString())).thenReturn(builder);
+                    when(builder.key(anyString())).thenReturn(builder);
+                    when(builder.preferredRegions(anyList())).thenReturn(builder);
+                    when(builder.buildClient()).thenReturn(mock(CosmosClient.class));
+                })) {
+
+            CosmosClient client = cfg.bizClient();
+            assertNotNull(client);
+
+            CosmosClientBuilder b = mocked.constructed().get(0);
+
+            verify(b).endpoint("https://biz-endpoint");
+            verify(b).key("biz-key");
+            verify(b).buildClient();
+
+            // preferredRegions must NOT be called
+            verify(b, never()).preferredRegions(anyList());
+        }
+    }
+
+    @Test
+    void shouldNotSetPreferredRegion_whenOptionalIsBlank() throws Exception {
+        CosmosClientsConfig cfg = baseConfig(Optional.of("   ")); // blank
+
+        try (MockedConstruction<CosmosClientBuilder> mocked = mockConstruction(
+                CosmosClientBuilder.class,
+                (builder, context) -> {
+                    when(builder.endpoint(anyString())).thenReturn(builder);
+                    when(builder.key(anyString())).thenReturn(builder);
+                    when(builder.preferredRegions(anyList())).thenReturn(builder);
+                    when(builder.buildClient()).thenReturn(mock(CosmosClient.class));
+                })) {
+
+            CosmosClient client = cfg.bizClient();
+            assertNotNull(client);
+
+            CosmosClientBuilder b = mocked.constructed().get(0);
+
+            verify(b).endpoint("https://biz-endpoint");
+            verify(b).key("biz-key");
+            verify(b).buildClient();
+
+            // blank -> not applied
+            verify(b, never()).preferredRegions(anyList());
+        }
+    }
+
+    @Test
+    void shouldSetPreferredRegion_whenOptionalIsPresent() throws Exception {
+        CosmosClientsConfig cfg = baseConfig(Optional.of(" North Europe ")); // with extra spaces, should be trimmed
+
+        try (MockedConstruction<CosmosClientBuilder> mocked = mockConstruction(
+                CosmosClientBuilder.class,
+                (builder, context) -> {
+                    when(builder.endpoint(anyString())).thenReturn(builder);
+                    when(builder.key(anyString())).thenReturn(builder);
+                    when(builder.preferredRegions(anyList())).thenReturn(builder);
+                    when(builder.buildClient()).thenReturn(mock(CosmosClient.class));
+                })) {
+
+            CosmosClient client = cfg.bizClient();
+            assertNotNull(client);
+
+            CosmosClientBuilder b = mocked.constructed().get(0);
+
+            verify(b).endpoint("https://biz-endpoint");
+            verify(b).key("biz-key");
+
+            // applied with value
+            verify(b).preferredRegions(List.of("North Europe"));
+
+            verify(b).buildClient();
+        }
+    }
+
+    @Test
+    void producerMethods_shouldUseCorrectEndpointsAndKeys() throws Exception {
+        CosmosClientsConfig cfg = baseConfig(Optional.of("North Europe"));
+
+        try (MockedConstruction<CosmosClientBuilder> mocked = mockConstruction(
+                CosmosClientBuilder.class,
+                (builder, context) -> {
+                    when(builder.endpoint(anyString())).thenReturn(builder);
+                    when(builder.key(anyString())).thenReturn(builder);
+                    when(builder.preferredRegions(anyList())).thenReturn(builder);
+                    when(builder.buildClient()).thenReturn(mock(CosmosClient.class));
+                })) {
+
+            assertNotNull(cfg.bizClient());
+            assertNotNull(cfg.negbizClient());
+            assertNotNull(cfg.verifyKoClient());
+
+            // 3 producers -> 3 builders
+            List<CosmosClientBuilder> builders = mocked.constructed();
+
+            CosmosClientBuilder b1 = builders.get(0);
+            verify(b1).endpoint("https://biz-endpoint");
+            verify(b1).key("biz-key");
+            verify(b1).preferredRegions(List.of("North Europe"));
+
+            CosmosClientBuilder b2 = builders.get(1);
+            verify(b2).endpoint("https://bizneg-endpoint");
+            verify(b2).key("bizneg-key");
+            verify(b2).preferredRegions(List.of("North Europe"));
+
+            CosmosClientBuilder b3 = builders.get(2);
+            verify(b3).endpoint("https://verifyko-endpoint");
+            verify(b3).key("verifyko-key");
+            verify(b3).preferredRegions(List.of("North Europe"));
+        }
+    }
+
+    // --------------------
+    // helpers
+    // --------------------
+
+    private static CosmosClientsConfig baseConfig(Optional<String> preferredRegion) throws Exception {
+        CosmosClientsConfig cfg = new CosmosClientsConfig();
+        setField(cfg, "bizendpoint", "https://biz-endpoint");
+        setField(cfg, "bizkey", "biz-key");
+        setField(cfg, "biznegendpoint", "https://bizneg-endpoint");
+        setField(cfg, "biznegkey", "bizneg-key");
+        setField(cfg, "verifykoendpoint", "https://verifyko-endpoint");
+        setField(cfg, "verifykokey", "verifyko-key");
+        setField(cfg, "preferredRegion", preferredRegion);
+        return cfg;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+}

--- a/src/test/java/it/gov/pagopa/nodetsworker/repository/PositionPaymentSSRepositoryTest.java
+++ b/src/test/java/it/gov/pagopa/nodetsworker/repository/PositionPaymentSSRepositoryTest.java
@@ -1,0 +1,89 @@
+package it.gov.pagopa.nodetsworker.repository;
+
+import it.gov.pagopa.nodetsworker.repository.models.PositionPaymentSSEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class PositionPaymentSSRepositoryTest {
+
+    private PositionPaymentSSRepository repo;
+    private EntityManager em;
+    private TypedQuery<PositionPaymentSSEntity> query;
+
+    @SuppressWarnings("unchecked")
+	@BeforeEach
+    void setup() throws Exception {
+        repo = new PositionPaymentSSRepository();
+        em = mock(EntityManager.class);
+        query = mock(TypedQuery.class);
+
+        setField(repo, "em", em);
+
+        when(em.createQuery(anyString(), eq(PositionPaymentSSEntity.class))).thenReturn(query);
+        when(query.setParameter(eq("token"), any())).thenReturn(query);
+        when(query.setMaxResults(1)).thenReturn(query);
+    }
+
+    @Test
+    void findByPaymentToken_shouldReturnEmpty_whenNoRows() {
+        when(query.getResultList()).thenReturn(List.of());
+
+        Optional<PositionPaymentSSEntity> res = repo.findByPaymentToken("pt-1");
+
+        assertTrue(res.isEmpty());
+
+        verify(em).createQuery(anyString(), eq(PositionPaymentSSEntity.class));
+        verify(query).setParameter("token", "pt-1");
+        verify(query).setMaxResults(1);
+        verify(query).getResultList();
+        verifyNoMoreInteractions(em, query);
+    }
+
+    @Test
+    void findByPaymentToken_shouldReturnFirst_whenHasRow() {
+        PositionPaymentSSEntity e = new PositionPaymentSSEntity();
+        when(query.getResultList()).thenReturn(List.of(e));
+
+        Optional<PositionPaymentSSEntity> res = repo.findByPaymentToken("pt-2");
+
+        assertTrue(res.isPresent());
+        assertSame(e, res.get());
+
+        verify(em).createQuery(anyString(), eq(PositionPaymentSSEntity.class));
+        verify(query).setParameter("token", "pt-2");
+        verify(query).setMaxResults(1);
+        verify(query).getResultList();
+        verifyNoMoreInteractions(em, query);
+    }
+
+    @Test
+    void findByPaymentToken_shouldUseExpectedJpqlShape() {
+        when(query.getResultList()).thenReturn(List.of());
+
+        repo.findByPaymentToken("pt-3");
+
+        verify(em).createQuery(argThat(jpql ->
+                        jpql.contains("FROM PositionPaymentSSEntity") &&
+                        jpql.contains("p.paymentToken = :token") &&
+                        jpql.contains("ORDER BY p.id DESC")
+                ),
+                eq(PositionPaymentSSEntity.class)
+        );
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+}

--- a/src/test/java/it/gov/pagopa/nodetsworker/resources/PositionPaymentSnapshotResourceTest.java
+++ b/src/test/java/it/gov/pagopa/nodetsworker/resources/PositionPaymentSnapshotResourceTest.java
@@ -1,0 +1,103 @@
+package it.gov.pagopa.nodetsworker.resources;
+
+import it.gov.pagopa.nodetsworker.exceptions.AppErrorCodeMessageEnum;
+import it.gov.pagopa.nodetsworker.exceptions.AppException;
+import it.gov.pagopa.nodetsworker.models.PositionPaymentSnapshotDto;
+import it.gov.pagopa.nodetsworker.service.PositionPaymentSnapshotService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+class PositionPaymentSnapshotResourceTest {
+
+    @InjectMock
+    PositionPaymentSnapshotService service;
+
+    @Test
+    void getByPaymentToken_shouldReturn200_andJsonBody() {
+        String token = "9ab5981f69744efb81f4ff67444e4d58";
+        String sid = "NDP003PROD";
+
+        PositionPaymentSnapshotDto dto = PositionPaymentSnapshotDto.builder()
+                .id(1680001L)
+                .paFiscalCode("00493410583")
+                .noticeId("396000000012231550")
+                .creditorReferenceId("96000000012231550")
+                .paymentToken(token)
+                .status("PAID_NORPT")
+                .insertedTimestamp(Instant.parse("2023-04-20T13:28:55.314Z"))
+                .updatedTimestamp(Instant.parse("2023-04-20T13:28:59.327Z"))
+                .fkPositionPayment(1660001L)
+                .insertedBy("activatePaymentNotice")
+                .updatedBy("sendPaymentOutcome")
+                .build();
+
+        when(service.getByPaymentToken(token, sid)).thenReturn(dto);
+
+        given()
+            .queryParam("serviceIdentifier", sid)
+        .when()
+            .get("/paymentToken/{paymentToken}", token)
+        .then()
+            .statusCode(200)
+            .body("id", is(1680001))
+            .body("pa_fiscal_code", is("00493410583"))
+            .body("notice_id", is("396000000012231550"))
+            .body("creditor_reference_id", is("96000000012231550"))
+            .body("payment_token", is(token))
+            .body("status", is("PAID_NORPT"))
+            .body("fk_position_payment", is(1660001))
+            .body("inserted_by", is("activatePaymentNotice"))
+            .body("updated_by", is("sendPaymentOutcome"));
+
+        verify(service, times(1)).getByPaymentToken(token, sid);
+    }
+    
+    @Test
+    void getByPaymentToken_shouldReturn404_whenNotFound() {
+        String token = "missing-token";
+        String sid = "NDP003PROD";
+
+        when(service.getByPaymentToken(token, sid))
+                .thenThrow(new AppException(AppErrorCodeMessageEnum.NOT_FOUND, "No snapshot row found"));
+
+        given()
+            .queryParam("serviceIdentifier", sid)
+        .when()
+            .get("/paymentToken/{paymentToken}", token)
+        .then()
+            .statusCode(404);
+    }
+    
+    @Test
+    void getByPaymentToken_shouldWork_withoutServiceIdentifier() {
+        String token = "9ab5981f69744efb81f4ff67444e4d58";
+
+        PositionPaymentSnapshotDto dto = PositionPaymentSnapshotDto.builder()
+                .id(1L)
+                .paFiscalCode("00493410583")
+                .noticeId("396000000012231550")
+                .creditorReferenceId("96000000012231550")
+                .paymentToken(token)
+                .status("PAID_NORPT")
+                .build();
+
+        when(service.getByPaymentToken(token, null)).thenReturn(dto);
+
+        given()
+        .when()
+            .get("/paymentToken/{paymentToken}", token)
+        .then()
+            .statusCode(200)
+            .body("payment_token", is(token));
+
+        verify(service, times(1)).getByPaymentToken(token, null);
+    }
+}

--- a/src/test/java/it/gov/pagopa/nodetsworker/service/NodeSnapshotRouterTest.java
+++ b/src/test/java/it/gov/pagopa/nodetsworker/service/NodeSnapshotRouterTest.java
@@ -1,0 +1,40 @@
+package it.gov.pagopa.nodetsworker.service;
+
+import it.gov.pagopa.nodetsworker.repository.PositionPaymentSnapshotReader;
+import it.gov.pagopa.nodetsworker.repository.qualifiers.DefaultNode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import jakarta.inject.Inject;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+class NodeSnapshotRouterTest {
+
+    @Inject
+    NodeSnapshotRouter router;
+
+    @InjectMock
+    @DefaultNode
+    PositionPaymentSnapshotReader defaultReader;
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "NDP003PROD", "NDP999PROD"})
+    void resolve_shouldUseDefaultReader_forAnyServiceIdentifier(String serviceIdentifier) {
+
+        when(defaultReader.findByPaymentToken("t")).thenReturn(Optional.empty());
+
+        PositionPaymentSnapshotReader resolved = router.resolve(serviceIdentifier);
+        resolved.findByPaymentToken("t");
+
+        // assert: if resolved is the default reader, then the call to findByPaymentToken should be executed by the default reader mock
+        verify(defaultReader, times(1)).findByPaymentToken("t");
+        verifyNoMoreInteractions(defaultReader);
+    }
+}

--- a/src/test/java/it/gov/pagopa/nodetsworker/service/PositionPaymentSnapshotServiceTest.java
+++ b/src/test/java/it/gov/pagopa/nodetsworker/service/PositionPaymentSnapshotServiceTest.java
@@ -1,0 +1,85 @@
+package it.gov.pagopa.nodetsworker.service;
+
+import it.gov.pagopa.nodetsworker.exceptions.AppException;
+import it.gov.pagopa.nodetsworker.models.PositionPaymentSnapshotDto;
+import it.gov.pagopa.nodetsworker.repository.PositionPaymentSnapshotReader;
+import it.gov.pagopa.nodetsworker.repository.models.PositionPaymentSSEntity;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+class PositionPaymentSnapshotServiceTest {
+
+    @Inject
+    PositionPaymentSnapshotService service;
+
+    @InjectMock
+    NodeSnapshotRouter router;
+
+    PositionPaymentSnapshotReader reader = mock(PositionPaymentSnapshotReader.class);
+
+    @Test
+    void getByPaymentToken_shouldReturnDto_andUseRouterWithServiceIdentifier() {
+        String token = "9ab5981f69744efb81f4ff67444e4d58";
+        String sid = "NDP003PROD";
+
+        when(router.resolve(sid)).thenReturn(reader);
+
+        PositionPaymentSSEntity entity = PositionPaymentSSEntity.builder()
+                .id(1680001L)
+                .paFiscalCode("00493410583")
+                .noticeId("396000000012231550")
+                .creditorReferenceId("96000000012231550")
+                .paymentToken(token)
+                .status("PAID_NORPT")
+                .insertedTimestamp(Instant.parse("2023-04-20T13:28:55.314Z"))
+                .updatedTimestamp(Instant.parse("2023-04-20T13:28:59.327Z"))
+                .fkPositionPayment(1660001L)
+                .insertedBy("activatePaymentNotice")
+                .updatedBY("sendPaymentOutcome")
+                .build();
+
+        when(reader.findByPaymentToken(token)).thenReturn(Optional.of(entity));
+
+        PositionPaymentSnapshotDto dto = service.getByPaymentToken(token, sid);
+
+        // verify interactions
+        verify(router, times(1)).resolve(sid);
+        verify(reader, times(1)).findByPaymentToken(token);
+
+        // verify mapping
+        assertEquals(1680001L, dto.getId());
+        assertEquals("00493410583", dto.getPaFiscalCode());
+        assertEquals("396000000012231550", dto.getNoticeId());
+        assertEquals("96000000012231550", dto.getCreditorReferenceId());
+        assertEquals(token, dto.getPaymentToken());
+        assertEquals("PAID_NORPT", dto.getStatus());
+        assertEquals(1660001L, dto.getFkPositionPayment());
+        assertEquals("activatePaymentNotice", dto.getInsertedBy());
+        assertEquals("sendPaymentOutcome", dto.getUpdatedBy());
+        assertNotNull(dto.getInsertedTimestamp());
+        assertNotNull(dto.getUpdatedTimestamp());
+    }
+
+    @Test
+    void getByPaymentToken_shouldThrowAppException_whenTokenNotFound() {
+        String token = "missing-token";
+        String sid = "NDP003PROD";
+
+        when(router.resolve(sid)).thenReturn(reader);
+        when(reader.findByPaymentToken(token)).thenReturn(Optional.empty());
+
+        assertThrows(AppException.class, () -> service.getByPaymentToken(token, sid));
+
+        verify(router, times(1)).resolve(sid);
+        verify(reader, times(1)).findByPaymentToken(token);
+    }
+}

--- a/src/test/java/it/gov/pagopa/nodetsworker/service/WorkerServiceTest.java
+++ b/src/test/java/it/gov/pagopa/nodetsworker/service/WorkerServiceTest.java
@@ -1,0 +1,267 @@
+package it.gov.pagopa.nodetsworker.service;
+
+import com.azure.cosmos.util.CosmosPagedIterable;
+import it.gov.pagopa.nodetsworker.exceptions.AppException;
+import it.gov.pagopa.nodetsworker.models.PaymentInfo;
+import it.gov.pagopa.nodetsworker.models.enums.PaymentStatus;
+import it.gov.pagopa.nodetsworker.repository.CosmosBizEventClient;
+import it.gov.pagopa.nodetsworker.repository.CosmosNegBizEventClient;
+import it.gov.pagopa.nodetsworker.repository.CosmosVerifyKOEventClient;
+import it.gov.pagopa.nodetsworker.repository.models.*;
+import it.gov.pagopa.nodetsworker.resources.response.PaymentsResponse;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+class WorkerServiceTest {
+
+    @Inject
+    WorkerService workerService;
+
+    @InjectMock
+    CosmosBizEventClient positiveBizClient;
+
+    @InjectMock
+    CosmosNegBizEventClient negativeBizClient;
+
+    @InjectMock
+    CosmosVerifyKOEventClient verifyKOEventClient;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(positiveBizClient, negativeBizClient, verifyKOEventClient);
+    }
+
+    @Test
+    void getInfoByNoticeNumber_shouldMapVerifyKoToFailed_andNegativeStatuses() {
+        String pa = "80007580279";
+        String notice = "301130001425371985";
+        LocalDate dateFrom = LocalDate.of(2026, 1, 21);
+        LocalDate dateTo   = LocalDate.of(2026, 1, 28);
+
+        VerifyKOEvent vko = mockVerifyKoEvent("vko-1", "2026-01-22T10:00:00.000Z", pa, notice, "01130001425371985");
+        PositiveBizEvent pbe = mockPositiveBizEvent("pbe-1", "2026-01-23T10:00:00.000Z", pa, notice, "01130001425371985", "token-ok-1");
+
+        NegativeBizEvent nbeFailed    = mockNegativeBizEvent("nbe-1", "sendPaymentOutcomeV2", "2026-01-24T10:00:00.000Z", pa, notice, "01130001425371985", "token-ko-1", true);
+        NegativeBizEvent nbeUnknown   = mockNegativeBizEvent("nbe-2", "nodoInviaRT",          "2026-01-25T10:00:00.000Z", pa, notice, "01130001425371985", "token-ko-2", true);
+        NegativeBizEvent nbeCancelled = mockNegativeBizEvent("nbe-3", "mod3CancelV2",         "2026-01-26T10:00:00.000Z", pa, notice, "01130001425371985", "token-ko-3", true);
+
+        CosmosPagedIterable<VerifyKOEvent> vkoPaged = cosmosIterableOf(List.of(vko));
+        CosmosPagedIterable<PositiveBizEvent> pbePaged = cosmosIterableOf(List.of(pbe));
+        CosmosPagedIterable<NegativeBizEvent> nbePaged = cosmosIterableOf(List.of(nbeFailed, nbeUnknown, nbeCancelled));
+
+        when(verifyKOEventClient.findEventsByCiAndNN(eq(pa), eq(notice), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(vkoPaged);
+
+        when(positiveBizClient.findEventsByCiAndNNAndToken(eq(pa), eq(notice), any(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(pbePaged);
+
+        when(negativeBizClient.findEventsByCiAndNNAndToken(eq(pa), eq(notice), any(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(nbePaged);
+
+        PaymentsResponse resp = workerService.getInfoByNoticeNumber(pa, notice, Optional.empty(), dateFrom, dateTo);
+
+        assertEquals(5, resp.getCount());
+        assertEquals(5, resp.getPayments().size());
+
+        List<PaymentInfo> list = resp.getPayments();
+
+        // order by insertedTimestamp
+        assertEquals("vko-1", list.get(0).getVerifyKoEvtId());
+        assertEquals("pbe-1", list.get(1).getPositiveBizEvtId());
+        assertEquals("nbe-1", list.get(2).getNegativeBizEvtId());
+        assertEquals("nbe-2", list.get(3).getNegativeBizEvtId());
+        assertEquals("nbe-3", list.get(4).getNegativeBizEvtId());
+
+        // status mapping
+        assertEquals(PaymentStatus.FAILED,    list.get(0).getStatus()); // VerifyKO
+        assertEquals(PaymentStatus.COMPLETED, list.get(1).getStatus()); // Positive
+        assertEquals(PaymentStatus.FAILED,    list.get(2).getStatus()); // sendPaymentOutcomeV2
+        assertEquals(PaymentStatus.UNKNOWN,   list.get(3).getStatus()); // nodoInviaRT
+        assertEquals(PaymentStatus.CANCELLED, list.get(4).getStatus()); // default
+
+        // outcome
+        assertEquals("KO", list.get(0).getOutcome());
+        assertEquals("OK", list.get(1).getOutcome());
+        assertEquals("KO", list.get(2).getOutcome());
+        assertEquals("KO", list.get(3).getOutcome());
+        assertEquals("KO", list.get(4).getOutcome());
+    }
+
+    @Test
+    void negativeEvent_outcomeShouldBeNull_whenReAwakableIsFalseOrNull() {
+        String pa = "80007580279";
+        String notice = "301130001425371985";
+        LocalDate dateFrom = LocalDate.of(2026, 1, 21);
+        LocalDate dateTo   = LocalDate.of(2026, 1, 28);
+
+        NegativeBizEvent nbeNull = mockNegativeBizEvent("nbe-1", "mod3CancelV2", "2026-01-24T10:00:00.000Z",
+                pa, notice, "01130001425371985", "token-1", null);
+        NegativeBizEvent nbeFalse = mockNegativeBizEvent("nbe-2", "mod3CancelV2", "2026-01-25T10:00:00.000Z",
+                pa, notice, "01130001425371985", "token-2", false);
+
+        CosmosPagedIterable<VerifyKOEvent> emptyVko = cosmosIterableOf(List.of());
+        CosmosPagedIterable<PositiveBizEvent> emptyPbe = cosmosIterableOf(List.of());
+        CosmosPagedIterable<NegativeBizEvent> negPaged = cosmosIterableOf(List.of(nbeNull, nbeFalse));
+
+        when(verifyKOEventClient.findEventsByCiAndNN(anyString(), anyString(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(emptyVko);
+        when(positiveBizClient.findEventsByCiAndNNAndToken(anyString(), anyString(), any(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(emptyPbe);
+        when(negativeBizClient.findEventsByCiAndNNAndToken(anyString(), anyString(), any(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(negPaged);
+
+        PaymentsResponse resp = workerService.getInfoByNoticeNumber(pa, notice, Optional.empty(), dateFrom, dateTo);
+
+        assertEquals(2, resp.getPayments().size());
+        assertNull(resp.getPayments().get(0).getOutcome());
+        assertNull(resp.getPayments().get(1).getOutcome());
+    }
+
+    @Test
+    void getNegativeBizEventById_shouldReturnEvent_whenPresent() {
+        NegativeBizEvent nbe = mock(NegativeBizEvent.class);
+
+        CosmosPagedIterable<NegativeBizEvent> paged = cosmosIterableOf(List.of(nbe));
+        when(negativeBizClient.getNegativeBizEventById("nbe-1")).thenReturn(paged);
+
+        NegativeBizEvent res = workerService.getNegativeBizEventById("nbe-1");
+        assertSame(nbe, res);
+    }
+
+    @Test
+    void getNegativeBizEventById_shouldThrowNotFound_whenMissing() {
+        CosmosPagedIterable<NegativeBizEvent> emptyPaged = cosmosIterableOf(List.of());
+        when(negativeBizClient.getNegativeBizEventById("missing")).thenReturn(emptyPaged);
+
+        assertThrows(AppException.class, () -> workerService.getNegativeBizEventById("missing"));
+    }
+
+    // -----------------------
+    // Helpers
+    // -----------------------
+
+    private static <T> CosmosPagedIterable<T> cosmosIterableOf(List<T> items) {
+        @SuppressWarnings("unchecked")
+        CosmosPagedIterable<T> paged = mock(CosmosPagedIterable.class);
+        doAnswer(inv -> items.stream()).when(paged).stream();
+        return paged;
+    }
+
+    private static VerifyKOEvent mockVerifyKoEvent(String id, String dateTimeIso, String pa, String noticeNumber, String iuv) {
+        return VerifyKOEvent.builder()
+                .id(id)
+                .serviceIdentifier("NDP003PROD")
+                .psp(Psp.builder()
+                        .idPsp("ABI03069")
+                        .idBrokerPsp("97249640588")
+                        .idChannel("97249640588_01")
+                        .build())
+                .creditor(Creditor.builder()
+                        .idPA(pa)
+                        .build())
+                .debtorPosition(DebtorPosition.builder()
+                        .noticeNumber(noticeNumber)
+                        .iuv(iuv)
+                        .build())
+                .faultBean(Fault.builder()
+                        .faultCode("PPT_VERIFY_KO")
+                        .description("desc")
+                        .dateTime(dateTimeIso)
+                        .timestamp(0L)
+                        .build())
+                .build();
+    }
+
+    private static PositiveBizEvent mockPositiveBizEvent(
+            String id,
+            String paymentDateTime,
+            String pa,
+            String noticeNumber,
+            String iuv,
+            String token) {
+
+        return PositiveBizEvent.builder()
+                .id(id)
+                .psp(Psp.builder()
+                        .idPsp("ABI03069")
+                        .idBrokerPsp("97249640588")
+                        .idChannel("97249640588_01")
+                        .build())
+                .creditor(Creditor.builder()
+                        .idPA(pa)
+                        .idBrokerPA("BROKER_PA")
+                        .idStation("STATION_01")
+                        .build())
+                .debtorPosition(DebtorPosition.builder()
+                        .noticeNumber(noticeNumber)
+                        .iuv(iuv)
+                        .build())
+                .paymentInfo(
+                        it.gov.pagopa.nodetsworker.repository.models.PaymentInfo.builder()
+                                .paymentDateTime(paymentDateTime)
+                                .paymentToken(token)
+                                .amount(null)
+                                .fee(null)
+                                .primaryCiIncurredFee(null)
+                                .paymentMethod(null)
+                                .touchpoint(null)
+                                .build()
+                )
+                .properties(Map.of("serviceIdentifier", "NDP003PROD"))
+                .build();
+    }
+
+    private static NegativeBizEvent mockNegativeBizEvent(
+            String id,
+            String businessProcess,
+            String paymentDateTime,
+            String pa,
+            String noticeNumber,
+            String iuv,
+            String token,
+            Boolean reAwakable) {
+
+        return NegativeBizEvent.builder()
+                .id(id)
+                .businessProcess(businessProcess)
+                .reAwakable(reAwakable)
+                .psp(Psp.builder()
+                        .idPsp("ABI03069")
+                        .idBrokerPsp("97249640588")
+                        .idChannel("97249640588_01")
+                        .build())
+                .creditor(Creditor.builder()
+                        .idPA(pa)
+                        .idBrokerPA("BROKER_PA")
+                        .idStation("STATION_01")
+                        .build())
+                .debtorPosition(DebtorPosition.builder()
+                        .noticeNumber(noticeNumber)
+                        .iuv(iuv)
+                        .build())
+                .paymentInfo(
+                        NegativePaymentInfo.builder()
+                                .paymentDateTime(paymentDateTime)
+                                .paymentToken(token)
+                                .amount(null)
+                                .paymentMethod(null)
+                                .touchpoint(null)
+                                .build()
+                )
+                .properties(Map.of("serviceIdentifier", "NDP003PROD"))
+                .build();
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Updated logic in WorkerService to correctly map and expose the status
- Added new API: `GET /paymentToken/{paymentToken}?serviceIdentifier={serviceIdentifier}` to retrieve Position Payment Snapshot by payment token.
- Introduced multi-node routing by `serviceIdentifier `(currently defaulting to single node)
- Configured Cosmos DB client to support preferred region for prod environment
- Minor refactoring and test stabilization


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The new /paymentToken API enables direct lookup of payment snapshot data and aligns with the new Position Payment Status Snapshot view.

The service is prepared for a future multi-node architecture. 

Cosmos DB configuration has been enhanced to support replica routing in production environments.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- junit tests
- manual test in DEV and UAT env

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.